### PR TITLE
Fix a bug when Docker build fails on some platforms

### DIFF
--- a/static/generated.go
+++ b/static/generated.go
@@ -29,7 +29,7 @@ COPY webapp /webapp
 WORKDIR webapp
 RUN npm install && npm run build
 
-FROM golang:1.14.0-alpine AS GO_BUILD
+FROM golang:1.13.8-alpine AS GO_BUILD
 RUN apk update && apk add build-base
 COPY server /server
 WORKDIR /server
@@ -1928,7 +1928,7 @@ func (m MongoDB) GetTechnologies() ([]*model.Technology, error) {
 `,
 		"server/go.mod": `module project-name
 
-go 1.14
+go 1.13
 
 require go.mongodb.org/mongo-driver v1.3.0
 `,

--- a/templates/Dockerfile
+++ b/templates/Dockerfile
@@ -3,7 +3,7 @@ COPY webapp /webapp
 WORKDIR webapp
 RUN npm install && npm run build
 
-FROM golang:1.14.0-alpine AS GO_BUILD
+FROM golang:1.13.8-alpine AS GO_BUILD
 RUN apk update && apk add build-base
 COPY server /server
 WORKDIR /server

--- a/templates/server/go.mod
+++ b/templates/server/go.mod
@@ -1,5 +1,5 @@
 module project-name
 
-go 1.14
+go 1.13
 
 require go.mongodb.org/mongo-driver v1.3.0


### PR DESCRIPTION
Fix a bug that leads to a docker-build failure on platforms with an old version of Linux kernel (such as the one used by the Alpine image).

Read more about the bug [here](https://github.com/golang/go/issues/37436).