### PR TITLE
feature: #100 Distribute Goxygen as a Docker image

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -98,6 +98,12 @@ You need to have Go 1.11 or newer on your machine.
 
 ## How to use
 
+Docker latest release:
+
+```bash
+docker run -e UID=$(echo $UID) -e GID=$(echo $GID) -v $(pwd):/app/generated ghcr.io/Shpota/goxygen:latest init my-app
+```
+
 Go 1.17 and later:
 
 ```go
@@ -110,10 +116,13 @@ go run github.com/shpota/goxygen@latest init my-app
 ### Go 1.16
 
 Set the `GO111MODULE` environment variable to `auto`.
+
 ```
 export GO111MODULE=auto
 ```
-Run 
+
+Run
+
 ```go
 go get -u github.com/shpota/goxygen
 go run github.com/shpota/goxygen init my-app
@@ -122,10 +131,12 @@ go run github.com/shpota/goxygen init my-app
 ### Go 1.11 - 1.15
 
 Run
+
 ```go
 go get -u github.com/shpota/goxygen
 go run github.com/shpota/goxygen init my-app
 ```
+
 </details>
 
 This generates a project in `my-app` folder.

--- a/.github/workflows/docker-build-package.yml
+++ b/.github/workflows/docker-build-package.yml
@@ -1,0 +1,40 @@
+name: build docker image and push
+
+on:
+  workflow_dispatch:
+  push:
+
+env:
+  IMAGE_NAME: goxygen
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build image
+        run: sudo docker build . --file Dockerfile --tag $IMAGE_NAME --label "runnumber=${GITHUB_RUN_ID}"
+
+      - name: Log in to registry
+        # This is where you will update the PAT to GITHUB_TOKEN
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Push image
+        run: |
+          IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
+          # Change all uppercase to lowercase
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+          # Strip "v" prefix from tag name
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+          # Use Docker `latest` tag convention
+          [ "$VERSION" == "master" ] && VERSION=latest
+          echo IMAGE_ID=$IMAGE_ID
+          echo VERSION=$VERSION
+          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
+          docker push $IMAGE_ID:$VERSION

--- a/.github/workflows/docker-build-package.yml
+++ b/.github/workflows/docker-build-package.yml
@@ -3,6 +3,11 @@ name: build docker image and push
 on:
   workflow_dispatch:
   push:
+    branches:
+      - master
+      - staging
+    tags:
+      - "*"
 
 env:
   IMAGE_NAME: goxygen

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM golang:1.17.6-bullseye
+
+ENV UID=1000
+ENV GID=1000
+ENV GOXYGEN_DOCKER=true
+
+WORKDIR /app
+COPY . .
+
+# Without this line, the docker image will not be able to run and produce error: 
+# `Failed to setup a Git repository: exit status 128`
+# Because there is a line of code that stage files to the git repository and commit on
+# codegen > codegen.go > function initGitRepo 
+RUN git config --global user.email "arlhba@gmail.com" && git config --global user.name "Luqmanul Hakim"
+
+RUN go build -o goxygen
+
+
+
+ENTRYPOINT ["/bin/sh", "-C", "/app/docker-entrypoint.sh" ]

--- a/codegen/codegen.go
+++ b/codegen/codegen.go
@@ -2,12 +2,13 @@ package codegen
 
 import (
 	"fmt"
-	"github.com/shpota/goxygen/static"
 	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
 	"strings"
+
+	"github.com/shpota/goxygen/static"
 )
 
 type generator struct {
@@ -17,6 +18,17 @@ type generator struct {
 
 func Generate(projectName string, techStack []string) {
 	g := generator{projectName, techStack}
+
+	// This code required to be able to run docker container so we could export generated files
+	if os.Getenv("GOXYGEN_DOCKER") == "true" {
+		_ = os.MkdirAll(
+			"generated",
+			os.ModePerm,
+		)
+
+		g.projectName = "generated/" + g.projectName
+	}
+
 	g.generate()
 }
 
@@ -53,9 +65,11 @@ func (g generator) processFile(path string, content []byte) {
 		strings.Join(pathElements[:len(pathElements)-1], separator),
 		os.ModePerm,
 	)
-	fmt.Println("creating: " + strings.Join(pathElements, separator))
+
+	pathFile := strings.Join(pathElements, separator)
+	fmt.Println("creating: " + pathFile)
 	err := ioutil.WriteFile(
-		strings.Join(pathElements, separator),
+		pathFile,
 		content,
 		0644,
 	)

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -e
+
+/app/goxygen $1 $2
+
+cd /app/generated/ 
+
+chown -R $UID:$GID /app/generated/$2


### PR DESCRIPTION
Hi I just made changes for #100 distributing Goxygen to GitHub Packages Docker

What changes will happen:
- When the branch master has a new commit, GitHub Action `docker-build-package` will trigger and create an image and push as `ghcr.io/Shpota/goxygen:latest`
- When a new tag is created GitHub Action `docker-build-package` will trigger and create an image and push as `ghcr.io/Shpota/goxygen:{new tag name}`
