### PR TITLE
Fix header for generated file static/generated.go

### DIFF
--- a/static/generated.go
+++ b/static/generated.go
@@ -1,4 +1,4 @@
-// THIS CODE IS GENERATED, DO NOT EDIT
+// Code generated from transform/transformer.go; DO NOT EDIT.
 
 // Package 'static' contains static assets such as
 // source code, text files or images generated form

--- a/transform/transformer.go
+++ b/transform/transformer.go
@@ -118,7 +118,8 @@ func sortedImagePaths(images map[string][]byte) []string {
 	return paths
 }
 
-const prefix = `// THIS CODE IS GENERATED, DO NOT EDIT
+// Standard header defined at https://golang.org/s/generatedcode
+const prefix = `// Code generated from transform/transformer.go; DO NOT EDIT.
 
 // Package 'static' contains static assets such as
 // source code, text files or images generated form


### PR DESCRIPTION
Use the standard header of the Go community defined at https://golang.org/s/generatedcode

The generator is adapted to produce the correct header.