### PR TITLE
transform: fix module path

### DIFF
--- a/transform/go.mod
+++ b/transform/go.mod
@@ -1,3 +1,3 @@
-module transform
+module github.com/shpota/goxygen/transform
 
 go 1.20


### PR DESCRIPTION
We are not Go stdlib. Use a module path `github.com/shpota/goxygen/transform` instead of just `transform`.