### PR TITLE
Add .mailmap to fix Git authorship

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,4 @@
+Sasha Shpota <5640984+Shpota@users.noreply.github.com> <sashashpota@gmail.com>
+Inna Shpota <25878403+shpotainna@users.noreply.github.com> <shpota_inna@ukr.net>
+Eddery Hassan <eddery.hassan@gmail.com>
+Jakob-em <26389546+Jakob-em@users.noreply.github.com> <26389546+Jakob-em@users.noreply.github.com>


### PR DESCRIPTION
Add .mailmap file to merge Git authors. See `git shortlog -s -e` for output difference.