### PR TITLE
CI: add detection of non-committed Go generated files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,10 @@ jobs:
         run: go test -v . ./cli ./codegen
       - name: Test Transformer
         run: cd transform && go test ./...
+      - name: Check generated code is committed
+        run: |
+          go generate ./...
+          git diff --exit-code
       - name: Lint
         run: |
           docker run -v $(pwd):/app -w /app golangci/golangci-lint:v1.24.0 \


### PR DESCRIPTION
Detect issues like #126 where templates had been updated but generated file static/generated.go not rebuilt.